### PR TITLE
fix: replace event-driven architecture with scheduled polling

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,13 +14,18 @@ output "lambda_role_arn" {
 }
 
 output "eventbridge_rule_arn" {
-  description = "ARN of the EventBridge rule that triggers AMI copying"
-  value       = aws_cloudwatch_event_rule.ami_shared.arn
+  description = "ARN of the EventBridge scheduled rule for AMI discovery"
+  value       = aws_cloudwatch_event_rule.ami_discovery.arn
 }
 
 output "eventbridge_rule_name" {
-  description = "Name of the EventBridge rule"
-  value       = aws_cloudwatch_event_rule.ami_shared.name
+  description = "Name of the EventBridge scheduled rule"
+  value       = aws_cloudwatch_event_rule.ami_discovery.name
+}
+
+output "schedule_expression" {
+  description = "Schedule expression for automated AMI discovery"
+  value       = var.schedule_expression
 }
 
 output "cloudwatch_log_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,13 +8,16 @@ variable "ami_name_template" {
   description = <<-EOT
     Template for naming copied AMIs. Available placeholders:
     - {source_name}: Name of the source AMI
+    - {uuid}: UUID extracted from Red Hat AMI name (composer-api-{uuid})
     - {date}: Current date/time in format YYYYMMDD-HHMMSS
     - {timestamp}: Unix timestamp
 
-    Example: 'rhel-{date}-encrypted-gp3' or '{source_name}-encrypted'
+    Example: 'rhel-{uuid}-encrypted-gp3' or '{source_name}-{uuid}-{date}'
+
+    Note: Including {uuid} ensures uniqueness and prevents duplicate copies.
   EOT
   type        = string
-  default     = "{source_name}-encrypted-gp3-{date}"
+  default     = "rhel-{uuid}-encrypted-gp3-{date}"
 }
 
 variable "tags" {
@@ -56,6 +59,23 @@ variable "log_retention_days" {
     ], var.log_retention_days)
     error_message = "Log retention days must be a valid CloudWatch Logs retention value."
   }
+}
+
+variable "schedule_expression" {
+  description = <<-EOT
+    EventBridge schedule expression for automated AMI discovery.
+    Uses rate() or cron() syntax.
+
+    Examples:
+    - 'rate(12 hours)' - Every 12 hours (default)
+    - 'rate(1 day)' - Once per day
+    - 'cron(0 */12 * * ? *)' - Every 12 hours using cron syntax
+    - 'cron(0 2 * * ? *)' - Daily at 2 AM UTC
+
+    See: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html
+  EOT
+  type        = string
+  default     = "rate(12 hours)"
 }
 
 variable "enable_redhat_api" {


### PR DESCRIPTION
## Problem

The current implementation uses an EventBridge rule to monitor `ModifyImageAttribute` API calls via CloudTrail, expecting these events when Red Hat Image Builder shares AMIs. However, according to [AWS documentation](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/monitor-use-of-a-shared-amazon-machine-image-across-multiple-aws-accounts.html), `ModifyImageAttribute` events are generated in the **creator account** (Red Hat's), not the consumer account where this module is deployed.

**Current (broken) flow:**
```
Red Hat shares AMI → ModifyImageAttribute in Red Hat's account → [Nothing in consumer account]
```

## Solution

Replace event-driven architecture with **scheduled polling**:

**New flow:**
```
EventBridge Schedule (12h) → Lambda → DescribeImages (Red Hat AMIs) → Copy new AMIs
Manual Invoke → Lambda → DescribeImages → Copy specific AMI
```

## Breaking Changes

⚠️ **This is a breaking change for existing deployments:**

- **EventBridge rule changed** from CloudTrail event pattern to scheduled expression
- **CloudTrail no longer required** (removes infrastructure dependency)
- **Lambda event structure changed** (scheduled events vs CloudTrail events)
- **Default `ami_name_template`** now includes `{uuid}` placeholder

### Migration Guide

If upgrading from a previous version:

1. **Update module configuration:**
   ```hcl
   module "ami_copier" {
     source = "git::https://github.com/PodioSpaz/ami-copier.git?ref=vX.X.X"

     # Add {uuid} to your template for deduplication
     ami_name_template = "rhel-{uuid}-encrypted-gp3"

     # Optional: customize polling schedule
     schedule_expression = "rate(12 hours)"
   }
   ```

2. **Apply Terraform changes** - EventBridge rule will be replaced
3. **No data migration needed** - Existing copied AMIs remain unchanged

## New Features

### 🔄 Scheduled Discovery
- Polls for shared Red Hat AMIs every 12 hours (configurable)
- Variable: `schedule_expression` supports rate() and cron() expressions
- Examples: `rate(6 hours)`, `cron(0 2 * * ? *)`

### 🎯 Manual Invocation
Direct Lambda invocation for on-demand processing:
```bash
# Process all shared AMIs
aws lambda invoke --function-name rhel-ami-copier --payload '{}' response.json

# Process specific AMI
aws lambda invoke --function-name rhel-ami-copier \
  --payload '{"source_ami_id":"ami-xxxxx"}' response.json
```

### 🔑 UUID Extraction
- Parses Red Hat AMI name pattern: `composer-api-{uuid}`
- Adds `{uuid}` placeholder to `ami_name_template`
- Tags copied AMIs with `SourceAMIUUID`

### ✅ Automatic Deduplication
- Checks if target AMI name already exists before copying
- Prevents duplicate copies on repeated scheduled runs
- Based on AMI name matching (owner: self)

## Implementation Details

### Core Functions

| Function | Purpose |
|----------|---------|
| `discover_shared_amis()` | Query AMIs from Red Hat account (463606842039) |
| `extract_uuid_from_ami_name()` | Parse UUID from `composer-api-{uuid}` pattern |
| `ami_already_copied()` | Check for existing copy by name |
| `process_ami()` | Unified processing: UUID extraction → dedup check → copy |
| `lambda_handler()` | Route scheduled vs manual invocations |

### Lambda Invocation Modes

**Scheduled Mode** (EventBridge trigger):
- Discovers all shared Red Hat AMIs
- Processes each with deduplication
- Returns summary: total, copied, skipped, errors

**Manual Mode** (direct invocation):
- Processes specific AMI from `source_ami_id` parameter
- Returns single result object

### EventBridge Changes

**Before:**
```hcl
event_pattern = {
  source      = ["aws.ec2"]
  detail-type = ["AWS API Call via CloudTrail"]
  detail = {
    eventName = ["ModifyImageAttribute"]
    # ...
  }
}
```

**After:**
```hcl
schedule_expression = "rate(12 hours)"  # Configurable
```

### New Variable

```hcl
variable "schedule_expression" {
  description = "EventBridge schedule expression"
  type        = string
  default     = "rate(12 hours)"
}
```

### Updated Default Template

```hcl
# Before
ami_name_template = "{source_name}-encrypted-gp3-{date}"

# After (includes UUID for uniqueness)
ami_name_template = "rhel-{uuid}-encrypted-gp3-{date}"
```

## Testing

### Unit Tests
- ✅ **47 tests passing** (92% code coverage)
- ✅ **New test classes:**
  - `TestExtractUuidFromAmiName` (5 tests)
  - `TestDiscoverSharedAmis` (3 tests)
  - `TestAmiAlreadyCopied` (3 tests)
- ✅ **Updated tests:**
  - Lambda handler for scheduled/manual modes
  - Generate AMI name with UUID placeholder
  - Copy AMI with UUID tag

### Example Output

**Scheduled mode:**
```json
{
  "statusCode": 200,
  "body": {
    "mode": "scheduled",
    "summary": {
      "total": 5,
      "copied": 2,
      "skipped": 3,
      "errors": 0
    },
    "results": [...]
  }
}
```

**Manual mode:**
```json
{
  "statusCode": 200,
  "body": {
    "mode": "manual",
    "result": {
      "source_ami_id": "ami-xxxxx",
      "new_ami_id": "ami-yyyyy",
      "ami_name": "rhel-uuid-encrypted",
      "uuid": "a1b2c3d4-...",
      "status": "copied"
    }
  }
}
```

## Documentation Updates

- ✅ README.md - Complete architecture rewrite
- ✅ CLAUDE.md - Updated troubleshooting and testing
- ✅ examples/basic/main.tf - New schedule_expression examples
- ✅ All references to CloudTrail removed

## Checklist

- [x] Issue #4 created documenting the problem
- [x] Architecture changed from event-driven to polling
- [x] UUID extraction implemented
- [x] Deduplication implemented
- [x] Scheduled polling (12h default)
- [x] Manual invocation mode
- [x] Unit tests updated (47 passing, 92% coverage)
- [x] Documentation updated (README, CLAUDE.md, examples)
- [x] Terraform validated
- [x] Breaking changes documented

## References

- Fixes #4
- [AWS Pattern: Cross-account AMI monitoring](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/monitor-use-of-a-shared-amazon-machine-image-across-multiple-aws-accounts.html)
- [AWS Sample: cross-account-ami-monitoring](https://github.com/aws-samples/cross-account-ami-monitoring-terraform-samples)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
