### PR TITLE
fix: remove Encrypted flag from block device mappings during re-registration

### DIFF
--- a/lambda/ami_copier.py
+++ b/lambda/ami_copier.py
@@ -71,6 +71,10 @@ def build_block_device_mappings_for_registration(block_device_mappings: List[Dic
                 ebs['VolumeType'] = 'gp3'
                 logger.info(f"Converting volume type from gp2 to gp3 for device {mapping['DeviceName']}")
 
+            # Remove Encrypted flag - encryption is inherited from the snapshot
+            # Specifying Encrypted when using existing snapshot IDs causes an error
+            ebs.pop('Encrypted', None)
+
             modified_mappings.append({
                 'DeviceName': mapping['DeviceName'],
                 'Ebs': ebs


### PR DESCRIPTION
## Summary

Follow-up fix for #14. While the two-step AMI copy process (merged in #15, released in v0.2.1) resolved the original `BlockDeviceMappings` parameter error, testing revealed a new issue during the re-registration step.

## Issue

When re-registering an AMI with `register_image()`, the `Encrypted` parameter cannot be specified in block device mappings when using existing snapshot IDs. AWS returns:

```
InvalidParameter: Parameter encrypted is invalid. You cannot specify the encrypted flag if specifying a snapshot id in a block device mapping.
```

Encryption status is automatically inherited from the snapshots themselves (which were encrypted during the `copy_image()` step).

## Fix

Remove the `Encrypted` flag from block device mappings in `build_block_device_mappings_for_registration()` before calling `register_image()`.

```python
# Remove Encrypted flag - encryption is inherited from the snapshot
# Specifying Encrypted when using existing snapshot IDs causes an error
ebs.pop('Encrypted', None)
```

## Testing

This addresses the error reported in [issue #14 comment](https://github.com/PodioSpaz/ami-copier/issues/14#issuecomment-3488181233) during v0.2.1 testing.

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
