### PR TITLE
chore: enable major version bump for breaking changes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
+      "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

Updates release-please configuration to correctly bump major version (1.0.0) for breaking changes instead of minor version (0.4.0).

## Problem

Currently, `bump-minor-pre-major: true` causes breaking changes (commits with `feat!:` or `BREAKING CHANGE:`) to only bump the minor version when in 0.x phase.

This resulted in PR #29 (which has breaking changes) being tagged for release as v0.4.0 instead of v1.0.0.

## Solution

Set `bump-minor-pre-major: false` to enable standard semver behavior where:
- Breaking changes → major version bump (0.3.2 → 1.0.0)
- Features → minor version bump (1.0.0 → 1.1.0)
- Fixes → patch version bump (1.0.0 → 1.0.1)

## Impact

After merging this PR:
1. Release-please will re-analyze commits on `main`
2. A new release PR will be automatically created with **v1.0.0** (instead of v0.4.0)
3. Future breaking changes will properly increment the major version

## Related

- Closes previous release PR #31 (v0.4.0 - incorrect)
- Will trigger new release PR for v1.0.0 after merge
- Follows up on PR #29 which introduced breaking changes