### PR TITLE
feat: add support for custom KMS key for cross-account AMI sharing

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -93,6 +93,37 @@ module "rhel10_copier" {
 #   }
 # }
 
+# Example: With custom KMS key for cross-account AMI sharing
+# Use this when you need to share encrypted AMIs with other AWS accounts
+# Uncomment and configure to enable
+# module "rhel9_with_kms" {
+#   source = "../.."
+#
+#   name_prefix       = "rhel9"
+#   ami_name_template = "rhel-9-{uuid}-encrypted"
+#
+#   # Specify customer-managed KMS key for encryption
+#   # The KMS key policy must grant permissions to this account and any target accounts
+#   # You can provide: full ARN, key ID (UUID), or alias
+#   kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+#   # kms_key_id = "12345678-1234-1234-1234-123456789012"  # Key ID format also works
+#   # kms_key_id = "alias/my-ami-encryption-key"           # Alias format also works
+#
+#   tags = {
+#     OS          = "RHEL"
+#     Version     = "9"
+#     Environment = "production"
+#   }
+# }
+#
+# # Example KMS key policy for cross-account sharing:
+# # The KMS key must grant the following permissions:
+# # 1. This account (AMI copier account) - encrypt, decrypt, create grants
+# # 2. Target account(s) - decrypt, describe key
+# #
+# # See AWS documentation for KMS key policy examples:
+# # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharingamis-explicit.html
+
 # Outputs
 output "lambda_function_arn" {
   description = "ARN of the Lambda function"


### PR DESCRIPTION
## Summary
- Added optional `kms_key_id` variable to support customer-managed KMS keys for AMI encryption
- Enables cross-account AMI sharing (AWS-managed keys cannot be shared across accounts)
- Supports three KMS key formats: full ARN, key ID (UUID), or alias
- Lambda IAM role automatically receives required KMS permissions when key is specified
- Maintains backward compatibility - uses AWS-managed key (`aws/ebs`) when `kms_key_id` is not set

## Changes
- **Lambda Functions**: Modified initiator.py to pass KMS key to `copy_image()` when `KMS_KEY_ID` environment variable is set
- **Terraform Module**: Added KMS key ARN construction logic and conditional IAM policy for KMS permissions
- **Variables**: Added `kms_key_id` variable with validation for ARN/UUID/alias formats
- **Documentation**: Updated README.md and CLAUDE.md with KMS key usage examples and troubleshooting
- **Examples**: Added commented example showing KMS key configuration for cross-account sharing
- **Tests**: Added test coverage for both KMS key and default encryption scenarios

## Test Plan
- [x] Verify Terraform validation accepts valid KMS key formats (ARN, UUID, alias)
- [x] Verify Terraform validation rejects invalid KMS key formats
- [x] Test Lambda function with KMS_KEY_ID environment variable set
- [x] Test Lambda function without KMS_KEY_ID (backward compatibility)
- [x] Verify IAM policy includes KMS permissions when key is specified
- [x] Verify IAM policy excludes KMS permissions when key is not specified
- [x] Review documentation for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)